### PR TITLE
Sentence casing, remove unneded translations

### DIFF
--- a/source/MouseView.cpp
+++ b/source/MouseView.cpp
@@ -12,8 +12,8 @@
 MouseView::MouseView()
 	: BView("MouseView", B_WILL_DRAW)
 {
-	Coord = new BStringView(B_TRANSLATE("Coord"), "X:0 Y:0");
-	Size = new BStringView(B_TRANSLATE("Size"), "- x -");
+	Coord = new BStringView("Coord", "X:0 Y:0");
+	Size = new BStringView("Size", "- x -");
 
 	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_HALF_ITEM_SPACING)
 		.SetInsets(B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING, B_USE_DEFAULT_SPACING)
@@ -27,7 +27,7 @@ void MouseView::ShowCoord(float x, float y)
 {
 	BString temp;
 	if(x > 4096 || x < 0 || y > 4096 || y < 0)
-		temp << B_TRANSLATE("Out of Range");
+		temp << B_TRANSLATE("Out of range");
 
 	else
 		temp << "X:" << ((uint32)x) << " Y:" << ((uint32)y);

--- a/source/OptionView.cpp
+++ b/source/OptionView.cpp
@@ -181,15 +181,15 @@ void OptionView::FillPopupEffect()
 {
 	BMessage* Rotation = new BMessage(CHANGE_EFFECT);
 	Rotation->AddInt16("Effect", ROTATE);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("90 Rotation"), Rotation));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("90° rotation"), Rotation));
 
 	BMessage* FlipH = new BMessage(CHANGE_EFFECT);
 	FlipH->AddInt16("Effect", FLIPH);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Flip Top-Bottom"), FlipH));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Flip top-bottom"), FlipH));
 
 	BMessage* FlipV = new BMessage(CHANGE_EFFECT);
 	FlipV->AddInt16("Effect", FLIPV);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Flip Left-Right"), FlipV));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Flip left-right"), FlipV));
 
 	BMessage* Light = new BMessage(CHANGE_EFFECT);
 	Light->AddInt16("Effect", LIGHT);
@@ -221,15 +221,15 @@ void OptionView::FillPopupEffect()
 
 	BMessage* Srg = new BMessage(CHANGE_EFFECT);
 	Srg->AddInt16("Effect", SRG);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap Red-Green"), Srg));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap red-green"), Srg));
 
 	BMessage* Srb = new BMessage(CHANGE_EFFECT);
 	Srb->AddInt16("Effect", SRB);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap Red-Blue"), Srb));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap red-blue"), Srb));
 
 	BMessage* Sgb = new BMessage(CHANGE_EFFECT);
 	Sgb->AddInt16("Effect", SGB);
-	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap Green-Blue"), Sgb));
+	PopupEffect->AddItem(new BMenuItem(B_TRANSLATE("Swap green-blue"), Sgb));
 
 	BMessage* Screenshot = new BMessage(CHANGE_EFFECT);
 	Screenshot->AddInt16("Effect", SCREENSHOT);

--- a/source/locales/en.catkeys
+++ b/source/locales/en.catkeys
@@ -1,9 +1,7 @@
-1	English	application/x-vnd.TAResizer	2403903214
-Size	MouseView		Size
+1	English	application/x-vnd.TAResizer	3281693760
 Darkness	OptionView		Darkness
-Flip Left-Right	OptionView		Flip Left-Right
+Flip left-right	OptionView		Flip left-right
 Reset	OptionView		Reset
-90 Rotation	OptionView		90 Rotation
 Undo	OptionView		Undo
 About	OptionView		About
 Light	OptionView		Light
@@ -12,29 +10,29 @@ The Awesome Resizer	System name		The Awesome Resizer
 Height	OptionView		Height
 Smooth scaling	OptionView		Smooth scaling
 Blur	OptionView		Blur
+Out of range	MouseView		Out of range
 Screenshot	OptionView		Screenshot
 Preserve aspect ratio	OptionView		Preserve aspect ratio
 Choose	OptionView		Choose
 Drunk	OptionView		Drunk
-Swap Green-Blue	OptionView		Swap Green-Blue
+Swap green-blue	OptionView		Swap green-blue
 Apply	OptionView		Apply
-Swap Red-Blue	OptionView		Swap Red-Blue
+Swap red-blue	OptionView		Swap red-blue
 Coordinates window	OptionView		Coordinates window
 Invert	OptionView		Invert
 TAResizer	OptionWindow		TAResizer
 Size:	OptionView		Size:
 A simple application that allows quick dynamic resizing of any translator supported image and much much more.	OptionWindow		A simple application that allows quick dynamic resizing of any translator supported image and much much more.
+90° rotation	OptionView		90° rotation
 Load	OptionView		Load
 Drag and drop an image	MainView		Drag and drop an image
-Coord	MouseView		Coord
 Filename:	OptionView		Filename:
 Save	OptionView		Save
 Format:	OptionView		Format:
-Swap Red-Green	OptionView		Swap Red-Green
+Swap red-green	OptionView		Swap red-green
 Options	OptionWindow		Options
 Choose an action	OptionView		Choose an action
 Working…	MainView		Working…
-Out of Range	MouseView		Out of Range
-Flip Top-Bottom	OptionView		Flip Top-Bottom
+Flip top-bottom	OptionView		Flip top-bottom
 Melt	OptionView		Melt
 Black & White	OptionView		Black & White


### PR DESCRIPTION
* The internal names for BStringViews don't need to be translated.
* Add "°" to 90° rotation.
* Sentence casing.