### PR TITLE
18 image window

### DIFF
--- a/source/MainView.cpp
+++ b/source/MainView.cpp
@@ -1112,3 +1112,10 @@ void MainView::InverseGB()
 	Invalidate();
 }
 //-------------------------------------------------------------------
+void MainView::ClearImage()
+{
+        OriginalBitmap = NULL;
+        Window()->ResizeTo(200, 100);
+        Window()->SetTitle(B_TRANSLATE("TAR: (No image)"));
+        Invalidate();
+}

--- a/source/MainView.cpp
+++ b/source/MainView.cpp
@@ -92,6 +92,11 @@ bool MainView::GetImage(const char* path)
 	ResizeTo(OriginalBitmap->Bounds().right, OriginalBitmap->Bounds().bottom); //grosseur originale
 	Window()->ResizeTo(OriginalBitmap->Bounds().right, OriginalBitmap->Bounds().bottom);
 	Flush(); //flush les vieux undo...
+	BString windowTitle(path);
+	windowTitle.Remove(0, windowTitle.FindLast("/") + 1);
+	windowTitle.Prepend("TAR: ");
+
+	Window()->SetTitle(windowTitle);
 	return true;
 }
 //----------------------------------------------------------------------

--- a/source/MainView.cpp
+++ b/source/MainView.cpp
@@ -1,18 +1,19 @@
-#include <Catalog.h>
 #include "MainView.h"
-#include <Path.h>
-#include <TranslationUtils.h>
-#include <TranslatorRoster.h>
+#include "RefFilters.h"
+#include "WindowTitleGuard.h"
+#include "main.h"
+#include <Application.h>
+#include <BitmapStream.h>
+#include <Catalog.h>
 #include <Directory.h>
 #include <File.h>
-#include <BitmapStream.h>
-#include <string.h>
 #include <NodeInfo.h>
+#include <Path.h>
 #include <Screen.h>
-#include <Application.h>
-#include "RefFilters.h"
-#include "main.h"
+#include <TranslationUtils.h>
+#include <TranslatorRoster.h>
 #include <stdlib.h>
+#include <string.h>
 
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "MainView"
@@ -651,7 +652,7 @@ void MainView::Dark()
 
 	rgb_color CurrentColor;
 	int r, g, b;
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
 		{
@@ -683,7 +684,7 @@ void MainView::Light()
 
 	rgb_color CurrentColor;
 	int r, g, b;
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
 		{
@@ -713,7 +714,7 @@ void MainView::Blur()
 	int height = (int)OriginalBitmap->Bounds().bottom+1;
 	int widthSize = (int)(OriginalBitmap->BytesPerRow()/4);
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 
 	rgb_color CC; //current color
 	rgb_color T; //top color
@@ -837,7 +838,7 @@ void MainView::BlackAndWhite()
 
 	rgb_color CurrentColor;
 	int moy;
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
 		{
@@ -875,7 +876,7 @@ void MainView::SmoothScale()
 	BBitmap* Smooth = new BBitmap(BRect(0,0, w-1, h-1), B_RGB32, true);
 	int widthSize = (int)(Smooth->BytesPerRow()/4);
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	for(y=0; y < h; y++)
 		for(x=0; x < w; x++)
 		{//pour chaque pixel
@@ -952,7 +953,7 @@ void MainView::Melt()
 	rgb_color RatioMajor, RatioMinor, RatioFinal;
 	RatioFinal.alpha = 255;
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	//premiere rangee, non modifiee
 	for(int RowSpecial = 0; RowSpecial < width; RowSpecial++)
 		((rgb_color *)Smoothed->Bits())[RowSpecial] =
@@ -985,7 +986,8 @@ void MainView::Invert()
 
 	rgb_color invertedColor;
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
 		{
@@ -1012,7 +1014,7 @@ void MainView::Drunk()
 	rgb_color PC; //preceding color
 	rgb_color NC; //next color
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	//premiere et derniere rangees non modifiee
 	for(int RowSpecial = 0; RowSpecial < width; RowSpecial++)
 		((rgb_color *)Barney->Bits())[RowSpecial] =
@@ -1046,7 +1048,7 @@ void MainView::InverseRG()
 	int height = (int)OriginalBitmap->Bounds().bottom+1;
 	int widthSize = (int)(OriginalBitmap->BytesPerRow()/4);
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	rgb_color invertedColor;
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
@@ -1071,7 +1073,7 @@ void MainView::InverseRB()
 	int height = (int)OriginalBitmap->Bounds().bottom+1;
 	int widthSize = (int)(OriginalBitmap->BytesPerRow()/4);
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	rgb_color invertedColor;
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)
@@ -1096,7 +1098,7 @@ void MainView::InverseGB()
 	int height = (int)OriginalBitmap->Bounds().bottom+1;
 	int widthSize = (int)(OriginalBitmap->BytesPerRow()/4);
 
-	Window()->SetTitle(B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
+	WindowTitleGuard guard(Window(), B_TRANSLATE("Working" B_UTF8_ELLIPSIS));
 	rgb_color invertedColor;
 	for(int row = 0; row < height; row++)
 		for(int col = 0; col < width; col++)

--- a/source/MainView.h
+++ b/source/MainView.h
@@ -66,6 +66,8 @@ class MainView : public BView
 	void AddBitmap(BBitmap* B); //add a bitmap to the deque
 	void Undo(); //Go back to previous image in deque
 	void Flush(); //Flush all image in the deque
+	bool HasImage() { return OriginalBitmap != NULL; }
+	void ClearImage();
 
  private:
 	BFilePanel*	 fOpenPanel;

--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -7,7 +7,7 @@
 
 //-------------------------------------------------------------------
 MainWindow::MainWindow()
-	: BWindow(BRect(240, 30, 440, 130), B_TRANSLATE_SYSTEM_NAME("The Awesome Resizer"),
+	: BWindow(BRect(240, 30, 440, 130), B_TRANSLATE("TA: (No image)"),
 	B_TITLED_WINDOW, B_NOT_ZOOMABLE | B_WILL_ACCEPT_FIRST_CLICK)
 {
 	Main = new MainView();
@@ -119,7 +119,7 @@ void MainWindow::MessageReceived(BMessage * message)
 
 		default:BWindow::MessageReceived(message);break;
 	}
-	SetTitle(B_TRANSLATE_SYSTEM_NAME("The Awesome Resizer"));
+	//SetTitle(B_TRANSLATE("TAR: (No image)"));
 	UpdateIfNeeded();
 }
 //-------------------------------------------------------------------

--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -8,8 +8,9 @@
 
 //-------------------------------------------------------------------
 MainWindow::MainWindow()
-	: BWindow(BRect(240, 30, 440, 130), B_TRANSLATE("TA: (No image)"),
-	B_TITLED_WINDOW, B_NOT_ZOOMABLE | B_WILL_ACCEPT_FIRST_CLICK)
+	:
+	BWindow(BRect(240, 30, 440, 130), B_TRANSLATE("TAR: (No image)"), B_DOCUMENT_WINDOW,
+		B_NOT_ZOOMABLE | B_WILL_ACCEPT_FIRST_CLICK)
 {
 	Main = new MainView();
 	AddChild(Main);
@@ -19,7 +20,7 @@ MainWindow::MainWindow()
 //-------------------------------------------------------------------
 bool MainWindow::QuitRequested()
 {
-	if(((Resizer*)be_app)->Option && !((Resizer*)be_app)->Option->IsHidden()) {
+	if (((Resizer*)be_app)->Option && !((Resizer*)be_app)->Option->IsHidden()) {
 		// If option window is still open, don't quit yet
 		if (Main->HasImage()) {
 			Main->ClearImage();
@@ -128,7 +129,6 @@ void MainWindow::MessageReceived(BMessage * message)
 
 		default:BWindow::MessageReceived(message);break;
 	}
-	//SetTitle(B_TRANSLATE("TAR: (No image)"));
 	UpdateIfNeeded();
 }
 //-------------------------------------------------------------------

--- a/source/MainWindow.cpp
+++ b/source/MainWindow.cpp
@@ -1,4 +1,5 @@
 #include "MainWindow.h"
+#include "main.h"
 #include <Application.h>
 #include <Catalog.h>
 
@@ -18,6 +19,14 @@ MainWindow::MainWindow()
 //-------------------------------------------------------------------
 bool MainWindow::QuitRequested()
 {
+	if(((Resizer*)be_app)->Option && !((Resizer*)be_app)->Option->IsHidden()) {
+		// If option window is still open, don't quit yet
+		if (Main->HasImage()) {
+			Main->ClearImage();
+			return false;
+		}
+	}
+
 	be_app->PostMessage(B_QUIT_REQUESTED);
 	return true; //on permet de quitter
 }

--- a/source/OptionWindow.cpp
+++ b/source/OptionWindow.cpp
@@ -11,7 +11,7 @@
 
 //-------------------------------------------------------------------
 OptionWindow::OptionWindow()
-	: BWindow(BRect(10, 30, 10, 30), B_TRANSLATE("Options"), B_TITLED_WINDOW,
+	: BWindow(BRect(10, 30, 10, 30), B_TRANSLATE_SYSTEM_NAME("The Awesome Resizer"), B_TITLED_WINDOW,
 	  B_NOT_ZOOMABLE | B_NOT_RESIZABLE | B_AUTO_UPDATE_SIZE_LIMITS)
 {
 	Option = new OptionView();

--- a/source/WindowTitleGuard.h
+++ b/source/WindowTitleGuard.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024, Johan Wagenheim <johan@dospuntos.no>
+ * All rights reserved. Distributed under the terms of the MIT license.
+ */
+
+#ifndef WINDOWTITLEGUARD_H
+#define WINDOWTITLEGUARD_H
+
+#include <Window.h>
+
+class WindowTitleGuard {
+public:
+	WindowTitleGuard(BWindow* window, BString tempTitle)
+		:
+		fWindow(window),
+		fOriginalTitle(window->Title())
+	{
+		fWindow->SetTitle(tempTitle);
+	}
+
+	~WindowTitleGuard() { fWindow->SetTitle(fOriginalTitle); }
+
+private:
+	BWindow* fWindow;
+	BString fOriginalTitle;
+};
+
+#endif // _H

--- a/source/locales/en.catkeys
+++ b/source/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.TAResizer	373938711
+1	English	application/x-vnd.TAResizer	1719132074
 Darkness	OptionView		Darkness
 Flip left-right	OptionView		Flip left-right
 Reset	OptionView		Reset
@@ -19,6 +19,8 @@ Drunk	OptionView		Drunk
 Swap green-blue	OptionView		Swap green-blue
 Apply	OptionView		Apply
 Swap red-blue	OptionView		Swap red-blue
+TAR: (No image)	MainView		TAR: (No image)
+TAR: (No image)	MainWindow		TAR: (No image)
 Coordinates window	OptionView		Coordinates window
 Invert	OptionView		Invert
 TAResizer	OptionWindow		TAResizer
@@ -27,11 +29,10 @@ A simple application that allows quick dynamic resizing of any translator suppor
 90° rotation	OptionView		90° rotation
 Load	OptionView		Load
 Drag and drop an image	MainView		Drag and drop an image
-Filename:	OptionView		Filename:
 Save	OptionView		Save
+Filename:	OptionView		Filename:
 Format:	OptionView		Format:
 Swap red-green	OptionView		Swap red-green
-Options	OptionWindow		Options
 Choose an action	OptionView		Choose an action
 Working…	MainView		Working…
 Flip top-bottom	OptionView		Flip top-bottom


### PR DESCRIPTION
This PR fixes #18 by changing how `QuitRequested()` is handled.

- Closing the Options window will always exit the app
- Closing the Image window when an image is open will close the image and show the drop-zone
- Closing the drop-zone when no image is open will exit the app

Other changes:
- Window titles (image window will show filename, Options window will show app name)
- The image window will show "Working..." while filters are applied, and revert to file name when done (can be hard to see, since most filters are applied almost instantly. Use a large image to test.) 