### PR TITLE
Improved resize handling with aspect-locking

### DIFF
--- a/source/MainView.cpp
+++ b/source/MainView.cpp
@@ -141,16 +141,9 @@ MainView::ResizeImage()
 	}
 
 	else if (fKeepRatio) { // resize the view while keeping the ratio intact
-		// ratio = width / height
-		if (winRect.bottom >= winRect.right / fRatio) {
-			// Adjustment as a function of width
-			ResizeTo(winRect.right, winRect.right / fRatio);
-			Window()->ResizeTo(winRect.right, winRect.right / fRatio);
-		} else {
-			// Adjustment as a function of width
-			ResizeTo(winRect.bottom * fRatio, winRect.bottom);
-			Window()->ResizeTo(winRect.bottom * fRatio, winRect.bottom);
-		}
+		// Adjustment as a function of width
+		ResizeTo(winRect.bottom * fRatio, winRect.bottom);
+		Window()->ResizeTo(winRect.bottom * fRatio, winRect.bottom);
 		Invalidate();
 	}
 


### PR DESCRIPTION
Before, the image window quickly behaved weirdly when repeatedly resizing the window with active aspect-locking. Move the mouse a few times up and down, and the window becomes very small...

This was due to considering horizontal and vertical movement of the mouse, it appears.
We now only consider the vertical movement and it works much nicer IMO, even though only vertical mouse movement resizes the window.